### PR TITLE
User 도메인 로직 생성

### DIFF
--- a/talk-main/src/main/java/com/locker/common/entity/BaseEntity.java
+++ b/talk-main/src/main/java/com/locker/common/entity/BaseEntity.java
@@ -21,18 +21,19 @@ public abstract class BaseEntity implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @CreatedBy
-    @Column(name = "created_by", updatable = false)
+    @Column(name = "created_by", nullable = false, updatable = false)
     private String createdBy;
 
     @LastModifiedBy
-    @Column(name = "updated_by")
+    @Column(name = "updated_by", nullable = false)
     private String updatedBy;
 
     @CreatedDate
-    @Column(name = "created_at", updatable = false)
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "updated_at")
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
 }

--- a/talk-main/src/main/java/com/locker/common/exception/model/ErrorCode.java
+++ b/talk-main/src/main/java/com/locker/common/exception/model/ErrorCode.java
@@ -1,25 +1,33 @@
 package com.locker.common.exception.model;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
 
     // USER
-    LOGIN_ID_REQUIRED(400, "로그인 아이디는 필수입니다."),
-    PASSWORD_REQUIRED(400, "비밀번호는 필수입니다."),
-    NICKNAME_REQUIRED(400, "닉네임은 필수입니다."),
-    FAVORITE_TEAM_ID_REQUIRED(400, "응원 팀 ID는 필수입니다."),
+    LOGIN_ID_REQUIRED               (HttpStatus.BAD_REQUEST, "로그인 아이디는 필수입니다."),
+    LOGIN_ID_LENGTH_INVALID         (HttpStatus.BAD_REQUEST, "로그인 아이디는 5~20자여야 합니다."),
+    LOGIN_ID_PATTERN_INVALID        (HttpStatus.BAD_REQUEST, "로그인 아이디는 영문 대·소문자와 숫자 조합만 허용됩니다."),
+    LOGIN_ID_DUPLICATE              (HttpStatus.CONFLICT, "중복된 로그인 아이디입니다."),
+    PASSWORD_REQUIRED               (HttpStatus.BAD_REQUEST, "비밀번호는 필수입니다."),
+    PASSWORD_LENGTH_INVALID         (HttpStatus.BAD_REQUEST, "비밀번호는 8자 이상 72자 이하여야 합니다."),
+    CONFIRM_PASSWORD_REQUIRED       (HttpStatus.BAD_REQUEST, "비밀번호 확인은 필수입니다."),
+    CONFIRM_PASSWORD_LENGTH_INVALID (HttpStatus.BAD_REQUEST, "비밀번호 확인은 8자 이상 72자 이하여야 합니다."),
+    PASSWORD_DO_NOT_MATCH           (HttpStatus.UNPROCESSABLE_ENTITY, "비밀번호가 일치하지 않습니다."),
+    NICKNAME_REQUIRED               (HttpStatus.BAD_REQUEST, "닉네임은 필수입니다."),
+    NICKNAME_LENGTH_INVALID         (HttpStatus.BAD_REQUEST, "닉네임은 5~20자여야 합니다."),
+    FAVORITE_TEAM_ID_REQUIRED       (HttpStatus.BAD_REQUEST, "응원 팀 ID는 필수입니다."),
 
     // COMMON
-    INVALID_REQUEST(400, "잘못된 요청입니다."),
-    NOT_FOUND(404, "리소스를 찾을 수 없습니다."),
-    INTERNAL_ERROR(500, "서버 에러가 발생했습니다.");
-
-    private final int status;
+    INVALID_REQUEST                 (HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    NOT_FOUND                       (HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다."),
+    INTERNAL_ERROR                  (HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다.");
+    private final HttpStatus status;
     private final String message;
 
-    ErrorCode(int status, String message) {
+    ErrorCode(HttpStatus status, String message) {
         this.status = status;
         this.message = message;
     }

--- a/talk-main/src/main/java/com/locker/common/exception/model/ErrorResponse.java
+++ b/talk-main/src/main/java/com/locker/common/exception/model/ErrorResponse.java
@@ -4,13 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 import lombok.ToString;
+import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
 @Data
 public class ErrorResponse {
 
-    private int status;
+    private HttpStatus status;
     private String message;
     private List<FieldError> errors;
 

--- a/talk-main/src/main/java/com/locker/common/exception/specific/UserException.java
+++ b/talk-main/src/main/java/com/locker/common/exception/specific/UserException.java
@@ -11,7 +11,13 @@ public class UserException extends CustomException {
     public static UserException loginIdBlank() {
         return new UserException(ErrorCode.LOGIN_ID_REQUIRED);
     }
-    public static UserException passwordBlank() {
-        return new UserException(ErrorCode.PASSWORD_REQUIRED);
+
+    public static UserException loginIdDuplicate() {
+        return new UserException(ErrorCode.LOGIN_ID_DUPLICATE);
     }
+
+    public static UserException passwordNotMatch() {
+        return new UserException(ErrorCode.PASSWORD_DO_NOT_MATCH);
+    }
+
 }

--- a/talk-main/src/main/java/com/locker/config/jpa/JpaConfig.java
+++ b/talk-main/src/main/java/com/locker/config/jpa/JpaConfig.java
@@ -1,10 +1,34 @@
 package com.locker.config.jpa;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Optional;
 
 @Configuration
 @EnableJpaAuditing
 @EnableJpaRepositories(basePackages = "com.locker")
-public class JpaConfig {}
+public class JpaConfig {
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return () -> {
+            var auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth == null
+                    || !auth.isAuthenticated()
+                    || auth instanceof AnonymousAuthenticationToken) {
+                // 회원가입(비인증) 시
+                return Optional.of("anonymous");
+            }
+            // 인증된 사용자의 로그인 아이디
+            return Optional.of(((UserDetails) auth.getPrincipal()).getUsername());
+        };
+    }
+
+}

--- a/talk-main/src/main/java/com/locker/config/security/SecurityConfig.java
+++ b/talk-main/src/main/java/com/locker/config/security/SecurityConfig.java
@@ -1,0 +1,34 @@
+package com.locker.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                // lambda style for CSRF
+                .csrf(csrf -> csrf.disable())
+                // all requests permitted
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
+                // disable form login
+                .formLogin(form -> form.disable())
+                // disable HTTP Basic
+                .httpBasic(basic -> basic.disable());
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/talk-main/src/main/java/com/locker/user/api/LoginRequest.java
+++ b/talk-main/src/main/java/com/locker/user/api/LoginRequest.java
@@ -1,0 +1,15 @@
+package com.locker.user.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "로그인 요청 DTO")
+public record LoginRequest(
+        @Schema(description = "로그인 아이디", example = "user01")
+        @NotBlank(message = "LOGIN_ID_REQUIRED")
+        String loginId,
+
+        @Schema(description = "비밀번호", example = "P@ssw0rd!")
+        @NotBlank(message = "PASSWORD_REQUIRED")
+        String password
+) {}

--- a/talk-main/src/main/java/com/locker/user/api/LoginResponse.java
+++ b/talk-main/src/main/java/com/locker/user/api/LoginResponse.java
@@ -1,0 +1,15 @@
+package com.locker.user.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LoginResponse(
+
+        @Schema(description = "발급된 JWT 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.DUMMY_PAYLOAD.DUMMY_SIG")
+        String token,
+
+        @Schema(description = "토큰 유형", example = "Bearer")
+        String tokenType,
+
+        @Schema(description = "만료 시간(UTC epoch millis)", example = "1716086400000")
+        Long expiresAt
+) {}

--- a/talk-main/src/main/java/com/locker/user/api/SignUpRequest.java
+++ b/talk-main/src/main/java/com/locker/user/api/SignUpRequest.java
@@ -1,0 +1,42 @@
+package com.locker.user.api;
+
+import com.locker.user.application.SignUpCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "회원가입 요청 DTO")
+public record SignUpRequest(
+        @Schema(description = "로그인 아이디", example = "user01")
+        @NotBlank(message = "LOGIN_ID_REQUIRED")
+        @Size(min = 5, max = 20, message = "LOGIN_ID_LENGTH_INVALID")
+        @Pattern(
+                regexp  = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)[A-Za-z\\d]+$",
+                message = "LOGIN_ID_PATTERN_INVALID"
+        )
+        String loginId,
+
+        @Schema(description = "비밀번호", example = "P@ssw0rd!1")
+        @NotBlank(message = "PASSWORD_REQUIRED")
+        @Size(min = 8, max = 72, message = "PASSWORD_LENGTH_INVALID")
+        String password,
+
+        @Schema(description = "비밀번호 확인", example = "P@ssw0rd!2")
+        @NotBlank(message = "CONFIRM_PASSWORD_REQUIRED")
+        @Size(min = 8, max = 72, message = "CONFIRM_PASSWORD_LENGTH_INVALID")
+        String confirmPassword,
+
+        @Schema(description = "닉네임", example = "김두한")
+        @NotBlank(message = "NICKNAME_REQUIRED")
+        @Size(min = 5, max = 20, message = "NICKNAME_LENGTH_INVALID")
+        String nickname,
+
+        @Schema(description = "응원 팀 ID (KBO 팀 코드)", example = "samsung")
+        @NotBlank(message = "FAVORITE_TEAM_ID_REQUIRED")
+        String favoriteTeamId
+) {
+        public SignUpCommand toCommand() {
+                return new SignUpCommand(loginId, password, confirmPassword, nickname, favoriteTeamId);
+        }
+}

--- a/talk-main/src/main/java/com/locker/user/api/UserController.java
+++ b/talk-main/src/main/java/com/locker/user/api/UserController.java
@@ -1,0 +1,48 @@
+package com.locker.user.api;
+
+import com.locker.user.application.UserFacade;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+@Validated // requestParam, pathVariable
+@Tag(name = "User API", description = "유저 관련 API 입니다.")
+public class UserController {
+
+    private final UserFacade userFacade;
+
+    @PostMapping
+    @Operation(summary = "회원가입", description = "아이디/비밀번호로 신규 회원을 등록합니다.")
+    public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequest req) {
+        userFacade.signUp(req.toCommand());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/exists")
+    @Operation(summary = "아이디 중복검사", description = "이미 존재하는 아이디가 있는지 확인합니다.")
+    public ResponseEntity<Boolean> exists(@RequestParam String loginId) {
+        return ResponseEntity.ok(userFacade.exists(loginId));
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인", description = "로그인 후 JWT 토큰을 발급받습니다.")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest req) {
+
+        String dummyJwt     = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.DUMMY_PAYLOAD.DUMMY_SIG";
+        String dummyType    = "Bearer";
+        Long   dummyExpires = System.currentTimeMillis() + 3600_000L; // 1시간 뒤
+        LoginResponse resp = new LoginResponse(dummyJwt, dummyType, dummyExpires);
+        return ResponseEntity.ok(resp);
+    }
+
+}

--- a/talk-main/src/main/java/com/locker/user/application/SignUpCommand.java
+++ b/talk-main/src/main/java/com/locker/user/application/SignUpCommand.java
@@ -1,0 +1,10 @@
+package com.locker.user.application;
+
+public record SignUpCommand(
+        String loginId,
+        String password,
+        String confirmPassword,
+        String nickname,
+        String favoriteTeamId
+) {
+}

--- a/talk-main/src/main/java/com/locker/user/application/UserFacade.java
+++ b/talk-main/src/main/java/com/locker/user/application/UserFacade.java
@@ -1,0 +1,22 @@
+package com.locker.user.application;
+
+import com.locker.user.domain.UserService;
+import com.locker.user.api.SignUpRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserFacade {
+
+    private final UserService userService;
+
+    public void signUp(SignUpCommand command) {
+        userService.signUp(command.loginId(), command.password(), command.confirmPassword(), command.nickname(), command.favoriteTeamId());
+    }
+
+    public Boolean exists(String loginId) {
+        return userService.existsByLoginId(loginId);
+    }
+
+}

--- a/talk-main/src/main/java/com/locker/user/domain/Provider.java
+++ b/talk-main/src/main/java/com/locker/user/domain/Provider.java
@@ -1,0 +1,7 @@
+package com.locker.user.domain;
+
+public enum Provider {
+    LOCAL,
+    GOOGLE,
+    KAKAO
+}

--- a/talk-main/src/main/java/com/locker/user/domain/Status.java
+++ b/talk-main/src/main/java/com/locker/user/domain/Status.java
@@ -1,0 +1,19 @@
+package com.locker.user.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum Status {
+    ACTIVE("활성"),
+    SUSPENDED("일시 정지"),
+    BANNED("영구 밴"),
+    WITHDRAWN("탈퇴"),
+    DORMANT("휴면");
+
+    private final String label;
+
+    Status(String label) {
+        this.label = label;
+    }
+
+}

--- a/talk-main/src/main/java/com/locker/user/domain/User.java
+++ b/talk-main/src/main/java/com/locker/user/domain/User.java
@@ -1,0 +1,105 @@
+package com.locker.user.domain;
+
+import com.locker.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+@Builder
+@Table(name = "`user`")
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "login_id", length = 20, unique = true)
+    private String loginId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+            name = "provider",
+            nullable = false,
+            columnDefinition = "VARCHAR(10) NOT NULL " + "CHECK (provider IN ('LOCAL','GOOGLE','KAKAO'))"
+    )
+    private Provider provider;
+
+    @Column(name = "provider_user_id", length = 100)
+    private String providerUserId;
+
+    @Column(name = "password", length = 255, nullable = false)
+    private String password;
+
+    @Column(name = "nickname", length = 20, nullable = false)
+    private String nickname;
+
+    @Column(name = "favorite_team_id", length = 20, nullable = false)
+    private String favoriteTeamId;
+
+    @Column(name = "profile_image_url", length = 255)
+    private String profileImageUrl;
+
+    @Column(name = "status_message", length = 200)
+    private String statusMessage;
+
+    @Enumerated(EnumType.STRING)
+    @Column(
+            name = "status",
+            nullable = false,
+            columnDefinition = "VARCHAR(10) NOT NULL " + "CHECK (status IN (" + "'ACTIVE','SUSPENDED','BANNED','WITHDRAWN','DORMANT'))"
+    )
+    private Status status;
+
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
+    @Column(name = "login_fail_count", nullable = false)
+    private Integer loginFailCount;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public static User createLocalUser(
+            String loginId,
+            String encodedPassword,
+            String nickname,
+            String favoriteTeamId
+    ) {
+        return User.builder()
+                .loginId(loginId)
+                .password(encodedPassword)
+                .nickname(nickname)
+                .favoriteTeamId(favoriteTeamId)
+                .provider(Provider.LOCAL)
+                .status(Status.ACTIVE)
+                .loginFailCount(0)
+                .build();
+    }
+
+    // 추가 예정
+    public void loginSucceeded(LocalDateTime now) {
+        this.lastLoginAt = now;
+        this.loginFailCount = 0;               // 실패 카운트 리셋
+        if (this.status == Status.SUSPENDED) {
+            this.status = Status.ACTIVE;       // 잠금 해제 로직이 있다면
+        }
+    }
+
+    public void loginFailed(int maxFailCount) {
+        this.loginFailCount++;
+        if (this.loginFailCount >= maxFailCount) {
+            this.status = Status.SUSPENDED;    // 일정 실패 횟수 이상이면 일시 정지
+        }
+    }
+
+    public void withdraw(LocalDateTime when) {
+        this.status = Status.WITHDRAWN;
+        this.deletedAt = when;
+    }
+
+}

--- a/talk-main/src/main/java/com/locker/user/domain/UserRepository.java
+++ b/talk-main/src/main/java/com/locker/user/domain/UserRepository.java
@@ -1,0 +1,13 @@
+package com.locker.user.domain;
+
+import java.util.Optional;
+
+public interface UserRepository {
+
+    void save(User user);
+
+    boolean existsByLoginId(String loginId);
+
+    Optional<User> findByLoginId(String loginId);
+
+}

--- a/talk-main/src/main/java/com/locker/user/domain/UserService.java
+++ b/talk-main/src/main/java/com/locker/user/domain/UserService.java
@@ -1,0 +1,43 @@
+package com.locker.user.domain;
+
+import com.locker.common.exception.specific.UserException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public boolean existsByLoginId(String loginId) {
+        return userRepository.existsByLoginId(loginId);
+    }
+
+    private void validateLoginIdNotDuplicate(String loginId) {
+        if (userRepository.existsByLoginId(loginId)) {
+            throw UserException.loginIdDuplicate();
+        }
+    }
+
+    @Transactional
+    public void signUp(String loginId, String password, String confirmPassword, String nickname, String favoriteTeamId) {
+
+        if (!password.equals(confirmPassword)) {
+            throw UserException.passwordNotMatch();
+        }
+
+        validateLoginIdNotDuplicate(loginId);
+
+        String encodedPassword = passwordEncoder.encode(password);
+        User user = User.createLocalUser(loginId, encodedPassword, nickname, favoriteTeamId);
+
+        userRepository.save(user);
+    }
+
+
+}

--- a/talk-main/src/main/java/com/locker/user/infra/UserJpaRepository.java
+++ b/talk-main/src/main/java/com/locker/user/infra/UserJpaRepository.java
@@ -1,0 +1,14 @@
+package com.locker.user.infra;
+
+import com.locker.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+
+    boolean existsByLoginId(String loginId);
+
+    Optional<User> findByLoginId(String loginId);
+
+}

--- a/talk-main/src/main/java/com/locker/user/infra/UserRepositoryImpl.java
+++ b/talk-main/src/main/java/com/locker/user/infra/UserRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.locker.user.infra;
+
+import com.locker.user.domain.User;
+import com.locker.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public void save(User user) {
+        userJpaRepository.save(user);
+    }
+
+    @Override
+    public boolean existsByLoginId(String loginId) {
+        return userJpaRepository.existsByLoginId(loginId);
+    }
+
+    @Override
+    public Optional<User> findByLoginId(String loginId) {
+        return userJpaRepository.findByLoginId(loginId);
+    }
+}

--- a/talk-main/src/main/resources/application.yml
+++ b/talk-main/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
     generate-ddl: false
     show-sql: false
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC

--- a/talk-main/src/main/resources/sql/schema.sql
+++ b/talk-main/src/main/resources/sql/schema.sql
@@ -2,13 +2,13 @@ DROP TABLE IF EXISTS `user`;
 
 CREATE TABLE `user` (
                         id                 BIGINT        AUTO_INCREMENT PRIMARY KEY COMMENT '유저 PK ID',
-                        login_id           VARCHAR(50)   NULL UNIQUE COMMENT '아이디',
+                        login_id           VARCHAR(20)   NULL UNIQUE COMMENT '아이디',
                         provider           VARCHAR(10)   NOT NULL DEFAULT 'LOCAL' COMMENT '가입 방식',
                                                          CHECK (provider IN ('LOCAL','GOOGLE','KAKAO')),
                         provider_user_id   VARCHAR(100)  NULL                COMMENT 'OAuth 공급자 유저 ID',
                         password           VARCHAR(255)  NOT NULL            COMMENT '패스워드',
-                        nickname           VARCHAR(50)   NOT NULL            COMMENT '닉네임',
-                        favorite_team_id   VARCHAR(50)   NOT NULL            COMMENT '유저 응원팀 ID',
+                        nickname           VARCHAR(20)   NOT NULL            COMMENT '닉네임',
+                        favorite_team_id   VARCHAR(20)   NOT NULL            COMMENT '유저 응원팀 ID',
                         profile_image_url  VARCHAR(255)  NULL                COMMENT '프로필 이미지 URL', -- 임시
                         status_message     VARCHAR(200)  NULL                COMMENT '한 줄 상태 메시지', -- 임시
                         status             VARCHAR(10)  NOT NULL DEFAULT 'ACTIVE' COMMENT '상태',
@@ -22,9 +22,9 @@ CREATE TABLE `user` (
                         last_login_at      DATETIME      NULL                COMMENT '마지막 로그인 날짜',
                         login_fail_count   INT           NOT NULL DEFAULT 0  COMMENT '로그인 실패 횟수',
                         deleted_at         DATETIME      NULL                COMMENT '탈퇴 시 탈퇴 날짜',
-                        created_by         VARCHAR(50)   NOT NULL            COMMENT '생성자',
+                        created_by         VARCHAR(50)   NOT NULL COMMENT '생성자',
                         created_at         DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성일',
-                        updated_by         VARCHAR(50)   NOT NULL            COMMENT '변경자',
+                        updated_by         VARCHAR(50)   NOT NULL COMMENT '변경자',
                         updated_at         DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '변경일',
                         INDEX idx_status      (status),
                         INDEX idx_last_login  (last_login_at)

--- a/talk-main/src/test/java/com/locker/configs/data/DataInitializationIntegrationTest.java
+++ b/talk-main/src/test/java/com/locker/configs/data/DataInitializationIntegrationTest.java
@@ -19,27 +19,32 @@ class DataInitializationIntegrationTest {
     private JdbcTemplate jdbc;
 
     @Test
-    @DisplayName("")
+    @DisplayName("Testcontainers 실행 시 schema.sql/data.sql이 정상적으로 적용된다")
     void Testcontainers_실행_시_DATA_SQL_SCHEMA_SQL_파일이_정상적으로_적용된다() {
-        // 테이블이 있는지 메타데이터로 확인
+        // 테이블 존재 여부 확인
         Integer tables = jdbc.queryForObject(
-                "SELECT COUNT(*) FROM information_schema.tables "
-                        + "WHERE table_schema = DATABASE() AND table_name = 'user'",
+                "SELECT COUNT(*) FROM information_schema.tables " +
+                        "WHERE table_schema = DATABASE() AND table_name = 'user'",
                 Integer.class);
         assertThat(tables).isOne();
 
-        // data.sql 에 INSERT 한 레코드가 들어있는지 확인
+        // data.sql 에서 INSERT 한 레코드가 들어있는지 확인 (nickname 값 일치)
+        String expectedNickname = "테스트유저1";
         Integer count = jdbc.queryForObject(
-                "SELECT COUNT(*) FROM `user` WHERE name = ?",
+                "SELECT COUNT(*) FROM `user` WHERE nickname = ?",
                 Integer.class,
-                "테스트");
+                expectedNickname);
         assertThat(count).isOne();
 
-        // 3)생성·수정 타임스탬프를 출력
+        // 생성·수정 타임스탬프 및 nickname 조회
         Map<String, Object> user = jdbc.queryForMap(
-                "SELECT id, name, created_at, updated_at FROM `user` WHERE name = ?",
-                "테스트");
+                "SELECT id, nickname, created_at, updated_at " +
+                        "FROM `user` WHERE nickname = ?",
+                expectedNickname);
         log.debug("테스트 유저 정보 : {} ", user);
-        assertThat(user.get("name")).isEqualTo("테스트");
+
+        assertThat(user.get("nickname")).isEqualTo(expectedNickname);
+        assertThat(user.get("created_at")).isNotNull();
+        assertThat(user.get("updated_at")).isNotNull();
     }
 }

--- a/talk-main/src/test/java/com/locker/user/UserServiceIntegrationTest.java
+++ b/talk-main/src/test/java/com/locker/user/UserServiceIntegrationTest.java
@@ -1,0 +1,108 @@
+package com.locker.user;
+
+import com.locker.common.exception.model.ErrorCode;
+import com.locker.common.exception.specific.UserException;
+import com.locker.user.domain.User;
+import com.locker.user.domain.UserRepository;
+import com.locker.user.domain.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class UserServiceIntegrationTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void cleanUp() {
+    }
+
+    @Test
+    void 회원가입_성공_시_User가_DB에_저장된다() {
+        // given
+        String loginId = "intgUser";
+        String pw      = "password";
+        String nick    = "intgNick";
+        String team    = "teamA";
+
+        // when
+        userService.signUp(loginId, pw, pw, nick, team);
+
+        // then
+        assertTrue(userService.existsByLoginId(loginId));
+
+        User saved = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new AssertionError("User가 저장되지 않았습니다."));
+        assertEquals(loginId,          saved.getLoginId());
+
+        assertNotEquals(pw,            saved.getPassword()); // PasswordEncoder가 실제 빈( BCrypt)을 사용하므로 원문과 다름
+        assertEquals(nick,             saved.getNickname());
+        assertEquals(team,             saved.getFavoriteTeamId());
+    }
+
+    @Test
+    void 회원가입_중_비밀번호_불일치_시_PASSWORD_DO_NOT_MATCH_예외가_발생한다() {
+        // when & then
+        UserException ex = assertThrows(UserException.class,
+                () -> userService.signUp("userX", "pw1", "pw2", "nick", "team")
+        );
+        assertEquals(ErrorCode.PASSWORD_DO_NOT_MATCH, ex.getErrorCode());
+    }
+
+    @Test
+    void 회원가입_중_아이디가_중복될_시_LOGIN_ID_DUPLICATE_예외가_발생한다() {
+        // given: 미리 사용자 저장
+        String loginId = "dupUser";
+        String encoded = passwordEncoder.encode("init");  // 직접 encoder 사용
+        userRepository.save(
+                User.createLocalUser(loginId, encoded, "nick", "teamA")
+        );
+
+        // when & then
+        UserException ex = assertThrows(UserException.class,
+                () -> userService.signUp(loginId, "pw", "pw", "nick2", "teamB")
+        );
+        assertEquals(ErrorCode.LOGIN_ID_DUPLICATE, ex.getErrorCode());
+    }
+
+    @Test
+    void 아이디_중복검사_시_아이디가_중복된다면_true를_반환한다() {
+        // given
+        String loginId = "existsUser";
+        String encoded = passwordEncoder.encode("pw");
+        userRepository.save(
+                User.createLocalUser(loginId, encoded, "nick", "teamA")
+        );
+
+        // when
+        boolean result = userService.existsByLoginId(loginId);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    void 아이디_중복검사_시_아이디가_중복되지_않는다면_false를_반환한다() {
+        // given
+
+        // when
+        boolean result = userService.existsByLoginId("noUser");
+
+        // then
+        assertFalse(result);
+    }
+}

--- a/talk-main/src/test/java/com/locker/user/UserServiceUnitTest.java
+++ b/talk-main/src/test/java/com/locker/user/UserServiceUnitTest.java
@@ -1,0 +1,88 @@
+package com.locker.user;
+
+import com.locker.common.exception.model.ErrorCode;
+import com.locker.common.exception.specific.UserException;
+import com.locker.user.domain.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceUnitTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void 회원가입_중_비밀번호_불일치_시_PASSWORD_DO_NOT_MATCH_예외가_발생한다() {
+        // given
+        String loginId = "user1", pw = "abc", confirm = "def";
+
+        // when & then
+        UserException ex = assertThrows(UserException.class,
+                () -> userService.signUp(loginId, pw, confirm, "nick", "team1"));
+        assertEquals(ErrorCode.PASSWORD_DO_NOT_MATCH, ex.getErrorCode());
+        verifyNoInteractions(userRepository);
+    }
+
+    @Test
+    void 회원가입_중_아이디가_중복될_시_LOGIN_ID_DUPLICATE_예외가_발생한다() {
+        // given
+        when(userRepository.existsByLoginId("user1")).thenReturn(true);
+
+        // when & then
+        UserException ex = assertThrows(UserException.class,
+                () -> userService.signUp("user1", "pw", "pw", "nick", "team1"));
+        assertEquals(ErrorCode.LOGIN_ID_DUPLICATE, ex.getErrorCode());
+        verify(userRepository).existsByLoginId("user1");
+        verifyNoMoreInteractions(userRepository);
+    }
+
+    @Test
+    void 회원가입_성공_시_User가_저장된다() {
+        // given
+        when(userRepository.existsByLoginId("user1")).thenReturn(false);
+        when(passwordEncoder.encode("pw")).thenReturn("ENCODED");
+
+        // when
+        userService.signUp("user1", "pw", "pw", "nick", "team1");
+
+        // then
+        verify(passwordEncoder).encode("pw");
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        User saved = captor.getValue();
+        assertEquals("user1",        saved.getLoginId());
+        assertEquals("ENCODED",      saved.getPassword());
+        assertEquals("nick",         saved.getNickname());
+        assertEquals("team1",        saved.getFavoriteTeamId());
+        assertEquals(Provider.LOCAL, saved.getProvider());
+        assertEquals(Status.ACTIVE,  saved.getStatus());
+    }
+
+    @Test
+    void existsByLoginId_호출_결과가_그대로_반환된다() {
+        // given
+        when(userRepository.existsByLoginId("test1")).thenReturn(true);
+        when(userRepository.existsByLoginId("test2")).thenReturn(false);
+
+        // when & then
+        assertTrue(userService.existsByLoginId("test1"));
+        assertFalse(userService.existsByLoginId("test2"));
+        verify(userRepository, times(2)).existsByLoginId(anyString());
+    }
+}


### PR DESCRIPTION
<!--
  PR을 제출하기 전에 아래 항목을 채워주세요.
# 📝 Pull Request
-->


## 🔖 개요
- User 도메인 로직 생성
- 설정 추가와 수정

<br>

## 📋 변경사항
- 🔨 **Refactor**
  - application.yml ddl-auto none 으로 변경
  - BaseEntity nullable false 추가, JpaConfig auditorProvider 로 권한별 처리
  - 암호화를 위한 임시 SecurityConfig 파일 생성
  - ErrorCode int status -> httpStatus 로 변경, 그에 따른 의존 클래스와 테스트 변경
  - schema.sql 자료형 변경


- 🆕 **Feature**
  - User 도메인 생성, 회원가입 로직 추가


<br>

## ✅ 체크리스트
- [ ] 코드가 빌드되고 주요 기능이 정상 동작합니다.
- [ ] 관련 유닛/통합 테스트를 추가했거나 기존 테스트가 통과합니다.
- [ ] CI 빌드가 성공하고 새로운 경고(warnings)가 없습니다.
- [ ] 필요한 경우 문서(README, API docs)를 업데이트했습니다.

<br>

## 🔗 관련 이슈/PR

#### 관련 이슈
- Security, jwt를 활용한 로그인,로그아웃 구현해야함
- 마이페이지 기능 구현해야함

#### 참조 PR
- 설정 변경, 추가 - a49d4b2 (securityconfig은 누락되어 하단 커밋)
- 유저 도메인 생성 및 회원가입 로직 추가 - 5900a12
- 유저 도메인 service 로직 단위테스트, 통합테스트 추가 - e8c2ff0

#### 고려해 봐야할 것
- 백엔드에서 프론트 예외처리는 아예 고려 안하고 따로 만들지

- 확장성/통일성을 고려하여 반드시 application의 facade를 태우는 형식을 쓸 지
- 하위 -> 상위 참조를 하지 않기 위해서 api -> application 은 api dto(request)에 변환로직을 만들어 application dto(command)로
  넘기는데, application dto -> domain service 로 넘길때는 domain이 application dto를 알면 하위 -> 상위참조라 언패킹 해서 넘김
  그래서 userFacade signUp은 dto를 언패킹해서 매개변수 5개로 넘기는데, 이 방법으로 하는게 맞는지 고민이 됨
  만약 언패킹한 매개변수가 20개라면?? 도메인에 도메인 객체를 외에 command를 받는 dto를 만들지 아니면 command를 넘기는걸 
  용인할지
  
- SignUpRequest 같은경우 Valid가 너무 복잡한데, 클래스를 더 나눌지 아니면 회원가입만 특히 복잡하니 저 양식 유지할지
- ErrorCode 하나의 클래스에 코드들이 너무 많아질 것 같은데, 나눌 수 있다면 CustomException처럼 부모-자식으로 나눌지

<br>

## 🖼️ 스크린샷 (Screenshots)
- UI/UX 변경이 있는 경우, Before/After 이미지 첨부

| Before | After |
| ------ | ----- |
| ![Before](https://dummyimage.com/150x100/cccccc/000000&text=Before) | ![After](https://dummyimage.com/150x100/444444/ffffff&text=After) |

<!--
## 📦 배포/런타임 (Run & Deploy)
-->
